### PR TITLE
ci: drop node 14 support and update deps and main test to node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     name: Build with ${{ matrix.node-version }}
@@ -31,7 +31,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     name: Run all tests
     runs-on: ubuntu-latest

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     name: Update all dependencies
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Built-in feature from Next.js:
 
 ### Requirements
 
-- Node.js 14+ and npm
+- Node.js 16+ and npm
 - WordPress CMS with GraphQL endpoint
 
 ### Commit Message Format


### PR DESCRIPTION
node 14 official support ends in April 2023

BREAKING CHANGE: no test for node 14